### PR TITLE
[chore] got rid of re assign node

### DIFF
--- a/src/back-end/enumToString.cpp
+++ b/src/back-end/enumToString.cpp
@@ -26,7 +26,6 @@ const char* nodeTypeToString(NODE_TYPE type)
         case DECL_LIST:      { return "DOUBLE";        }
         case EXPR_STMT:      { return "EXPR_STMT";     }
         case POINT:          { return "POINT";         }
-        case REASSIGN:       { return "REASSIGN";      }
         case UN_OP:          { return "UN_OP";         }
         case EDGE:           { return "EDGE";          }
         case RETURN_EVAL:    { return "RETURN_EVAL";   }
@@ -43,12 +42,12 @@ const char* nodeTypeToString(NODE_TYPE type)
 const char* nodeOpToString(NODE_OP nodeOp)
 {
     switch (nodeOp) {
-        case OP_PLUS:   { return "+";    } 
-        case OP_SUB:    { return "-";    }
-        case OP_MUL:    { return "*";    }
-        case OP_DIV:    { return "/";    }
-        case OP_MOD:    { return "mod";  }
-        case OP_ASSIGN: { return ":=";   }
+        case OP_PLUS:     { return "+";    } 
+        case OP_SUB:      { return "-";    }
+        case OP_MUL:      { return "*";    }
+        case OP_DIV:      { return "/";    }
+        case OP_MOD:      { return "mod";  }
+        case OP_REASSIGN: { return ":=";   }
         default: {
             fprintf(stderr, "Hit default case in nodeTypeToString() exiting...\n");
             exit(0);

--- a/src/back-end/functions.cpp
+++ b/src/back-end/functions.cpp
@@ -118,13 +118,13 @@ void startViewer()
 */
 void _addShapeVtk(const TopoDS_Shape& shapeToAdd)
 {
-    //vtkNew<IVtkTools_ShapeDataSource> occSourceOne;
-    //occSourceOne->SetShape(new IVtkOCC_Shape(shapeToAdd));
-    //vtkNew<vtkPolyDataMapper> mapperOne;
-    //mapperOne->SetInputConnection(occSourceOne->GetOutputPort());
-    //vtkNew<vtkActor> actorOne;
-    //actorOne->SetMapper(mapperOne);
-    //ren->AddActor(actorOne);
+    vtkNew<IVtkTools_ShapeDataSource> occSourceOne;
+    occSourceOne->SetShape(new IVtkOCC_Shape(shapeToAdd));
+    vtkNew<vtkPolyDataMapper> mapperOne;
+    mapperOne->SetInputConnection(occSourceOne->GetOutputPort());
+    vtkNew<vtkActor> actorOne;
+    actorOne->SetMapper(mapperOne);
+    ren->AddActor(actorOne);
 }
 
 

--- a/src/back-end/functions.cpp
+++ b/src/back-end/functions.cpp
@@ -118,13 +118,13 @@ void startViewer()
 */
 void _addShapeVtk(const TopoDS_Shape& shapeToAdd)
 {
-    vtkNew<IVtkTools_ShapeDataSource> occSourceOne;
-    occSourceOne->SetShape(new IVtkOCC_Shape(shapeToAdd));
-    vtkNew<vtkPolyDataMapper> mapperOne;
-    mapperOne->SetInputConnection(occSourceOne->GetOutputPort());
-    vtkNew<vtkActor> actorOne;
-    actorOne->SetMapper(mapperOne);
-    ren->AddActor(actorOne);
+    //vtkNew<IVtkTools_ShapeDataSource> occSourceOne;
+    //occSourceOne->SetShape(new IVtkOCC_Shape(shapeToAdd));
+    //vtkNew<vtkPolyDataMapper> mapperOne;
+    //mapperOne->SetInputConnection(occSourceOne->GetOutputPort());
+    //vtkNew<vtkActor> actorOne;
+    //actorOne->SetMapper(mapperOne);
+    //ren->AddActor(actorOne);
 }
 
 

--- a/src/back-end/node.hxx
+++ b/src/back-end/node.hxx
@@ -34,7 +34,7 @@ typedef enum nodeOp {
     OP_MUL,
     OP_DIV,
     OP_MOD,
-    OP_ASSIGN,
+    OP_REASSIGN,
     OP_PIPE,
     OP_NEGATE
 } NODE_OP;
@@ -69,7 +69,6 @@ typedef enum nodeType {
     UNTIL,
 
     DECL,
-    REASSIGN,
     STMT,
 
     FUNCTION,
@@ -354,25 +353,6 @@ class NodeDecl: public NodeStatement {
 };
 
 
-class NodeReAssign: public NodeStatement {
-    public:
-        NodeIdentifier* id;
-        NodeExpression* value;
-
-    NodeReAssign(
-        NodeIdentifier* id,
-        NodeExpression* value,
-        Node* _prevAlloc
-    ): id(id), value(value) {
-        this->nextStmt = NULL;
-        this->nodeType = REASSIGN;
-
-        this->_allocatedLinkedList = _prevAlloc;
-    }
-
-};
-
-
 class NodeStmtList: public Node {
     public:
         NodeStatement* nextStmt; 
@@ -548,7 +528,6 @@ NodeEdge* newNodeEdge();
 NodePoint* newNodePoint();
 NodeBinaryOperator* newBinaryOperatorNode(NodeExpression* lhs, NodeExpression* rhs, NODE_OP binaryOperatorType);
 NodeDecl* newDeclNode(NodeIdentifier* id, NodeType* type, NodeExpression* value, DECL_MUT_STATE mutState);
-NodeReAssign* newReAssignNode(NodeIdentifier* id, NodeExpression* value);
 NodeStmtList* newStmtList(NodeStatement* nextStmt);
 NodeDeclList* newDeclList(NodeDecl* nextDecl);
 NodeBlock* newNodeBlock(NodeStmtList* stmts);

--- a/src/back-end/nodeAllocFree.cpp
+++ b/src/back-end/nodeAllocFree.cpp
@@ -149,14 +149,6 @@ NodeDecl* newDeclNode(NodeIdentifier* id, NodeType* type, NodeExpression* value,
 }
 
 
-NodeReAssign* newReAssignNode(NodeIdentifier* id, NodeExpression* value)
-{
-    NodeReAssign* me = new NodeReAssign(id, value, _prevAlloc);
-    _prevAlloc = me;
-    return me;
-}
-
-
 NodeStmtList* newStmtList(NodeStatement* nextStmt)
 {
     NodeStmtList* me = new NodeStmtList(nextStmt, _prevAlloc);

--- a/src/back-end/parser.y
+++ b/src/back-end/parser.y
@@ -61,7 +61,6 @@ extern void yyerror( YYLTYPE *, void *, void *, const char * );
 
 
   NodeDecl*       declNode;
-  NodeReAssign*   reAssignNode;
 
   NodeIdentifier* idNode;
   NodeType*       typeNode;
@@ -116,7 +115,6 @@ extern void yyerror( YYLTYPE *, void *, void *, const char * );
 %type <untilNode>                    untilStmt
 
 %type <declNode>                     paramDecl declStmt
-%type <reAssignNode>                 reAssignStmt
 
 %type <declList>                     paramDeclList
 %type <stmtListNodes>                stmtList 
@@ -157,7 +155,6 @@ stmt:
     block           { $$ = $1; }
   | functionStmt    { $$ = $1; }
   | declStmt        { $$ = $1; }
-  | reAssignStmt    { $$ = $1; }
   | exprStmt        { $$ = $1; }
   | returnStmt      { $$ = $1; }
   ;
@@ -208,10 +205,6 @@ paramDecl:
   ;
 
 
-reAssignStmt:
-    tok_ID tok_ASSIGN expr { $$ = newReAssignNode($1, $3); }
-  ;
-
 
 declStmt:
     tok_LET tok_ID ':' tok_TYPE initOpt {
@@ -244,7 +237,7 @@ expr:
   | expr '*' expr                  { $$ = newBinaryOperatorNode($1, $3, OP_MUL); }
   | expr '/' expr                  { $$ = newBinaryOperatorNode($1, $3, OP_DIV); }
   | expr tok_PIPE expr             { $$ = newBinaryOperatorNode($1, $3, OP_PIPE); }
-  | expr tok_ASSIGN expr           { $$ = newBinaryOperatorNode($1, $3, OP_ASSIGN); }
+  | expr tok_ASSIGN expr           { $$ = newBinaryOperatorNode($1, $3, OP_REASSIGN); }
   | tok_NUM                        { $$ = $1; }
   | '[' arrayList ']'              { $$ = newArrayNode($2); } 
   | tok_ID                         { $$ = $1; }

--- a/tests/vtk_test.cpp
+++ b/tests/vtk_test.cpp
@@ -13,7 +13,7 @@ TAU_MAIN()
 
 TEST(VTK, testOne) {
     
-    FILE* filePtr = fopen("/home/alfredo/repos/OpenKittenCad/tests/input_tests/vtkInputFive.kts", "r");
+    FILE* filePtr = fopen("/home/alfredo/repos/OpenKittenCad/tests/input_tests/vtkInputFour.kts", "r");
     
     if(!filePtr){
         fprintf(stderr, "Error opening file semantic testOne\n");


### PR DESCRIPTION
I noticed it when I was checking for shift/reduce errors with bison and noticed there was a shift reduce error. It then showed to me that I had a rule for re assignment something like this 

```txt
reAssignRule:
tok_ID tok_ASSIGN expr
```

but I also had the following


```txt
binOpRule:
tok_ID tok_ASSIGN expr
```

The one below seemed like the right choice since it really was just a binary operation happening. Decided to get rid of the top rule and all the logic for it in the semantic file.